### PR TITLE
Support for API Keys

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -123,7 +123,7 @@ func insertTestUser2024Lyon() (models.User, string) {
 	return u, token
 }
 
-func insertTestApiKeyUser() (models.User, string) {
+func insertTestAPIKeyUser() (models.User, string) {
 	u := models.User{
 		Login: "api_key",
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -123,6 +123,15 @@ func insertTestUser2024Lyon() (models.User, string) {
 	return u, token
 }
 
+func insertTestApiKeyUser() (models.User, string) {
+	u := models.User{
+		Login: "api_key",
+	}
+
+	token, _, _ := AuthMiddleware().TokenGenerator(&u)
+	return u, token
+}
+
 func insertTestTeacher() (models.User, string) {
 	u := models.User{
 		Name:    "Teacher",

--- a/api/auth.go
+++ b/api/auth.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/aureleoules/epitaf/lib/microsoft"
@@ -52,6 +53,17 @@ func authenticateHandler(c *gin.Context) {
 // @Failure 500 "Server error"
 // @Router /users/callback [POST]
 func callbackHandler(c *gin.Context) (interface{}, error) {
+	// Check if the request is using an API KEY
+	auth := c.Request.Header.Get("Authorization")
+	if auth != "" {
+		token := strings.TrimPrefix(auth, "Bearer ")
+		if models.IsApiKeyCorrect(token) {
+			return &models.User{
+				Login: "api_key",
+			}, nil
+		}
+	}
+
 	var m map[string]string
 	err := c.Bind(&m)
 	if err != nil {

--- a/api/auth.go
+++ b/api/auth.go
@@ -57,7 +57,7 @@ func callbackHandler(c *gin.Context) (interface{}, error) {
 	auth := c.Request.Header.Get("Authorization")
 	if auth != "" {
 		token := strings.TrimPrefix(auth, "Bearer ")
-		if models.IsApiKeyCorrect(token) {
+		if models.IsAPIKeyCorrect(token) {
 			return &models.User{
 				Login: "api_key",
 			}, nil

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -34,7 +34,12 @@ func AuthMiddleware() *jwt.GinJWTMiddleware {
 		},
 		Authenticator: callbackHandler,
 		Authorizator: func(data interface{}, c *gin.Context) bool {
-			return true
+			// Authorize api key user only on /v1/tasks route
+			if v, ok := data.(*models.User); ok && v.Login == "api_key" {
+				return c.FullPath() == "/v1/tasks"
+			} else {
+				return true
+			}
 		},
 		Unauthorized: func(c *gin.Context, code int, message string) {
 			_ = c.AbortWithError(code, errors.New(message))

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -307,6 +307,44 @@ func getTasksHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, tasks)
 }
 
+// @Summary Gets all tasks
+// @Tags tasks
+// @Description Get tasks
+// @Success 200	"OK"
+// @Failure 401	"Unauthorized"
+// @Failure 404	"Not found"
+// @Failure 406	"Not acceptable"
+// @Failure 500 "Server error" "Server error"
+// @Router /tasks/all [GET]
+// func getAllTasksHandler(c *gin.Context) {
+// 	var tasks []models.Task
+
+// 	var query models.Filters
+// 	err := c.BindQuery(&query)
+// 	if err != nil {
+// 		zap.S().Error(err)
+// 		c.AbortWithStatus(http.StatusNotAcceptable)
+// 		return
+// 	}
+// 	err = query.Validate()
+// 	if err != nil {
+// 		zap.S().Error(err)
+// 		c.AbortWithStatus(http.StatusNotAcceptable)
+// 		return
+// 	}
+
+// 	tasks, err = models.GetTasksRange(*u, query)
+
+// 	if err != nil {
+// 		zap.S().Error(err)
+// 		c.AbortWithStatus(http.StatusInternalServerError)
+// 		return
+// 	}
+
+// 	zap.S().Info("Fetched all tasks.")
+// 	c.JSON(http.StatusOK, tasks)
+// }
+
 // @Summary Create task
 // @Tags tasks
 // @Description Create a new task

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -297,7 +297,7 @@ func getTasksHandler(c *gin.Context) {
 		if u.Login != "api_key" {
 			tasks, err = models.GetTasksRange(*u, query)
 		} else {
-			tasks, err = models.GetAllTasks()
+			tasks, err = models.GetAllTasks(query.StartDate, query.EndDate)
 		}
 	}
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -294,7 +294,11 @@ func getTasksHandler(c *gin.Context) {
 	if u.Teacher {
 		tasks, err = models.GetTeacherTasksRange(query.StartDate, query.EndDate)
 	} else {
-		tasks, err = models.GetTasksRange(*u, query)
+		if u.Login != "api_key" {
+			tasks, err = models.GetTasksRange(*u, query)
+		} else {
+			tasks, err = models.GetAllTasks()
+		}
 	}
 
 	if err != nil {
@@ -306,44 +310,6 @@ func getTasksHandler(c *gin.Context) {
 	zap.S().Info(u.Name + " fetched tasks.")
 	c.JSON(http.StatusOK, tasks)
 }
-
-// @Summary Gets all tasks
-// @Tags tasks
-// @Description Get tasks
-// @Success 200	"OK"
-// @Failure 401	"Unauthorized"
-// @Failure 404	"Not found"
-// @Failure 406	"Not acceptable"
-// @Failure 500 "Server error" "Server error"
-// @Router /tasks/all [GET]
-// func getAllTasksHandler(c *gin.Context) {
-// 	var tasks []models.Task
-
-// 	var query models.Filters
-// 	err := c.BindQuery(&query)
-// 	if err != nil {
-// 		zap.S().Error(err)
-// 		c.AbortWithStatus(http.StatusNotAcceptable)
-// 		return
-// 	}
-// 	err = query.Validate()
-// 	if err != nil {
-// 		zap.S().Error(err)
-// 		c.AbortWithStatus(http.StatusNotAcceptable)
-// 		return
-// 	}
-
-// 	tasks, err = models.GetTasksRange(*u, query)
-
-// 	if err != nil {
-// 		zap.S().Error(err)
-// 		c.AbortWithStatus(http.StatusInternalServerError)
-// 		return
-// 	}
-
-// 	zap.S().Info("Fetched all tasks.")
-// 	c.JSON(http.StatusOK, tasks)
-// }
 
 // @Summary Create task
 // @Tags tasks

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -682,7 +682,7 @@ func Test_getTasksHandler(t *testing.T) {
 	refreshDB()
 	u1, token1 := insertTestUser2024C1()
 	u2, _ := insertTestUser2025C1()
-	_, tokenApi := insertTestApiKeyUser()
+	_, tokenAPI := insertTestAPIKeyUser()
 
 	// Check unauthorized
 	apitest.New().
@@ -762,7 +762,7 @@ func Test_getTasksHandler(t *testing.T) {
 	r = apitest.New().
 		Handler(createRouter()).
 		Get("/v1/tasks").
-		Header("Authorization", "Bearer "+tokenApi).
+		Header("Authorization", "Bearer "+tokenAPI).
 		Expect(t).
 		Status(http.StatusOK).
 		End()

--- a/cmd/apikey.go
+++ b/cmd/apikey.go
@@ -15,23 +15,29 @@ func init() {
 }
 
 var apiKeyCmd = &cobra.Command{
-	Use:   "apikey",
-	Short: "Generates a new api key",
+	Use:     "apikey",
+	Example: "epitaf apikey <label>",
+	Short:   "Generates a new api key",
+	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		db.Connect()
 
-		newAPIKey := ""
-		for i := 0; i < 8; i++ {
-			newAPIKey += shortid.MustGenerate()
+		newAPIKey := models.APIKey{
+			Token: "",
+			Label: args[0],
 		}
-		newAPIKey = newAPIKey[:64]
 
-		err := models.InsertAPIKey(newAPIKey)
+		for i := 0; i < 8; i++ {
+			newAPIKey.Token += shortid.MustGenerate()
+		}
+		newAPIKey.Token = newAPIKey.Token[:64]
+
+		err := newAPIKey.Insert()
 		if err != nil {
 			zap.S().Error(err)
 			return
 		}
 
-		fmt.Printf("\033[32m%s\033[0m\n", newAPIKey)
+		fmt.Printf("\033[32m%s => %s\033[0m\n", newAPIKey.Label, newAPIKey.Token)
 	},
 }

--- a/cmd/apikey.go
+++ b/cmd/apikey.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/aureleoules/epitaf/db"
+	"github.com/aureleoules/epitaf/models"
+	"github.com/spf13/cobra"
+	"github.com/teris-io/shortid"
+	"go.uber.org/zap"
+)
+
+func init() {
+	rootCmd.AddCommand(apiKeyCmd)
+}
+
+var apiKeyCmd = &cobra.Command{
+	Use:   "apikey",
+	Short: "Generates a new api key",
+	Run: func(cmd *cobra.Command, args []string) {
+		db.Connect()
+
+		newApiKey := ""
+		for i := 0; i < 8; i++ {
+			newApiKey += shortid.MustGenerate()
+		}
+		newApiKey = newApiKey[:64]
+
+		err := models.InsertApiKey(newApiKey)
+		if err != nil {
+			zap.S().Error(err)
+			return
+		}
+
+		fmt.Printf("\033[32m%s\033[0m\n", newApiKey)
+	},
+}

--- a/cmd/apikey.go
+++ b/cmd/apikey.go
@@ -20,18 +20,18 @@ var apiKeyCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		db.Connect()
 
-		newApiKey := ""
+		newAPIKey := ""
 		for i := 0; i < 8; i++ {
-			newApiKey += shortid.MustGenerate()
+			newAPIKey += shortid.MustGenerate()
 		}
-		newApiKey = newApiKey[:64]
+		newAPIKey = newAPIKey[:64]
 
-		err := models.InsertApiKey(newApiKey)
+		err := models.InsertAPIKey(newAPIKey)
 		if err != nil {
 			zap.S().Error(err)
 			return
 		}
 
-		fmt.Printf("\033[32m%s\033[0m\n", newApiKey)
+		fmt.Printf("\033[32m%s\033[0m\n", newAPIKey)
 	},
 }

--- a/db/db.go
+++ b/db/db.go
@@ -27,7 +27,7 @@ func connect(host, user, pass, database string) {
 	}
 	zap.S().Info("Connecting to database...")
 	var err error
-	DB, err = sqlx.Connect("mysql", user+":"+pass+"@("+host+":3306)/"+database+"?charset=utf8mb4,utf8&parseTime=true&loc=Europe%2FParis&time_zone=%27Europe%2FParis%27")
+	DB, err = sqlx.Connect("mysql", user+":"+pass+"@("+host+")/"+database+"?charset=utf8mb4,utf8&parseTime=true&loc=Europe%2FParis&time_zone=%27Europe%2FParis%27")
 	if err != nil {
 		zap.S().Error(err)
 		time.Sleep(5 * time.Second)

--- a/db/db.go
+++ b/db/db.go
@@ -27,7 +27,7 @@ func connect(host, user, pass, database string) {
 	}
 	zap.S().Info("Connecting to database...")
 	var err error
-	DB, err = sqlx.Connect("mysql", user+":"+pass+"@("+host+")/"+database+"?charset=utf8mb4,utf8&parseTime=true&loc=Europe%2FParis&time_zone=%27Europe%2FParis%27")
+	DB, err = sqlx.Connect("mysql", user+":"+pass+"@("+host+":3306)/"+database+"?charset=utf8mb4,utf8&parseTime=true&loc=Europe%2FParis&time_zone=%27Europe%2FParis%27")
 	if err != nil {
 		zap.S().Error(err)
 		time.Sleep(5 * time.Second)

--- a/models/api_keys.go
+++ b/models/api_keys.go
@@ -1,26 +1,47 @@
 package models
 
+import (
+	"github.com/aureleoules/epitaf/db"
+	"go.uber.org/zap"
+)
+
 const (
 	apiKeySchema = `
 		CREATE TABLE api_keys (
-			key VARCHAR(64) NOT NULL UNIQUE,
+			api_key VARCHAR(64) NOT NULL UNIQUE,
 
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
 
-			PRIMARY KEY (key)
+			PRIMARY KEY (api_key)
 		);
+	`
+
+	getApiKey = `
+		SELECT 
+			api_key
+		FROM api_keys
+		WHERE api_key = ?;
 	`
 )
 
-// Members string
-type ApiKey []string
-
-// Includes checks if s is included in slice
-func (m ApiKey) Includes(s string) bool {
-	for _, a := range m {
-		if a == s {
-			return true
-		}
+// IsApiKeyCorrect checks if the api key is registered
+func IsApiKeyCorrect(api_key string) bool {
+	zap.S().Info("Retrieving api key...")
+	tx, err := db.DB.Beginx()
+	if err != nil {
+		return false
 	}
-	return false
+
+	defer checkErr(tx, err)
+
+	var exists *[]uint8
+
+	err = tx.Get(&exists, getApiKey, api_key)
+	if err != nil {
+		zap.S().Error(err)
+		zap.S().Info("Api key '", api_key, "' does not exists")
+		return false
+	}
+	zap.S().Info("Retrieved api key.")
+	return true
 }

--- a/models/api_keys.go
+++ b/models/api_keys.go
@@ -22,7 +22,27 @@ const (
 		FROM api_keys
 		WHERE api_key = ?;
 	`
+
+	insertApiKey = `
+		INSERT INTO api_keys
+			(api_key)
+		VALUES
+			(?);
+	`
 )
+
+// Insert task in DB
+func InsertApiKey(api_key string) error {
+	tx, err := db.DB.Beginx()
+	if err != nil {
+		return err
+	}
+
+	defer checkErr(tx, err)
+
+	_, err = tx.Exec(insertApiKey, api_key)
+	return err
+}
 
 // IsApiKeyCorrect checks if the api key is registered
 func IsApiKeyCorrect(api_key string) bool {

--- a/models/api_keys.go
+++ b/models/api_keys.go
@@ -16,14 +16,14 @@ const (
 		);
 	`
 
-	getApiKey = `
+	getAPIKey = `
 		SELECT 
 			api_key
 		FROM api_keys
 		WHERE api_key = ?;
 	`
 
-	insertApiKey = `
+	insertAPIKey = `
 		INSERT INTO api_keys
 			(api_key)
 		VALUES
@@ -31,8 +31,8 @@ const (
 	`
 )
 
-// Insert task in DB
-func InsertApiKey(api_key string) error {
+// InsertAPIKey inserts API key in DB
+func InsertAPIKey(apiKey string) error {
 	tx, err := db.DB.Beginx()
 	if err != nil {
 		return err
@@ -40,12 +40,12 @@ func InsertApiKey(api_key string) error {
 
 	defer checkErr(tx, err)
 
-	_, err = tx.Exec(insertApiKey, api_key)
+	_, err = tx.Exec(insertAPIKey, apiKey)
 	return err
 }
 
-// IsApiKeyCorrect checks if the api key is registered
-func IsApiKeyCorrect(api_key string) bool {
+// IsAPIKeyCorrect checks if the API key is registered
+func IsAPIKeyCorrect(apiKey string) bool {
 	zap.S().Info("Retrieving api key...")
 	tx, err := db.DB.Beginx()
 	if err != nil {
@@ -56,10 +56,10 @@ func IsApiKeyCorrect(api_key string) bool {
 
 	var exists *[]uint8
 
-	err = tx.Get(&exists, getApiKey, api_key)
+	err = tx.Get(&exists, getAPIKey, apiKey)
 	if err != nil {
 		zap.S().Error(err)
-		zap.S().Info("Api key '", api_key, "' does not exists")
+		zap.S().Info("Api key '", apiKey, "' does not exists")
 		return false
 	}
 	zap.S().Info("Retrieved api key.")

--- a/models/api_keys.go
+++ b/models/api_keys.go
@@ -1,0 +1,26 @@
+package models
+
+const (
+	apiKeySchema = `
+		CREATE TABLE api_keys (
+			key VARCHAR(64) NOT NULL UNIQUE,
+
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
+
+			PRIMARY KEY (key)
+		);
+	`
+)
+
+// Members string
+type ApiKey []string
+
+// Includes checks if s is included in slice
+func (m ApiKey) Includes(s string) bool {
+	for _, a := range m {
+		if a == s {
+			return true
+		}
+	}
+	return false
+}

--- a/models/api_keys.go
+++ b/models/api_keys.go
@@ -40,7 +40,7 @@ type APIKey struct {
 	Label string
 }
 
-// InsertAPIKey inserts API key in DB
+// APIKey.Insert inserts API key in DB
 func (a *APIKey) Insert() error {
 	tx, err := db.DB.Beginx()
 	if err != nil {

--- a/models/api_keys.go
+++ b/models/api_keys.go
@@ -40,7 +40,7 @@ type APIKey struct {
 	Label string
 }
 
-// APIKey.Insert inserts API key in DB
+// Insert inserts API key in DB
 func (a *APIKey) Insert() error {
 	tx, err := db.DB.Beginx()
 	if err != nil {

--- a/models/schemas.go
+++ b/models/schemas.go
@@ -5,7 +5,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var schemas = []string{userSchema, taskSchema, completedTaskSchema}
+var schemas = []string{userSchema, taskSchema, completedTaskSchema, apiKeySchema}
 
 // InjectSQLSchemas injects sql schemas in db
 func InjectSQLSchemas() error {

--- a/models/task.go
+++ b/models/task.go
@@ -551,6 +551,20 @@ func GetUserTask(id, login string) (*Task, error) {
 }
 
 // GetTasksRange returns list of tasks in a time for a specific class promotion
+// func GetAllTasks(filters Filters) ([]Task, error) {
+// 	tx, err := db.DB.Beginx()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	defer checkErr(tx, err)
+
+// 	var tasks []Task
+// 	err = tx.Select(&tasks, getTasksRangeQuery, user.Login, filters.Visibility, filters.Subject, filters.Completed, user.Login, user.Promotion, user.Class, user.Region, user.Semester, user.Promotion, user.Semester, "%"+user.Login+"%", user.Login, filters.StartDate, filters.EndDate)
+// 	return tasks, err
+// }
+
+// GetTasksRange returns list of tasks in a time for a specific class promotion
 func GetTasksRange(user User, filters Filters) ([]Task, error) {
 	tx, err := db.DB.Beginx()
 	if err != nil {

--- a/models/task.go
+++ b/models/task.go
@@ -123,7 +123,9 @@ const (
 			updated_user.login = tasks.updated_by_login
 		WHERE 
 			tasks.visibility='promotion'
-			AND deleted=0;
+			AND deleted=0
+			AND due_date >= ? 
+			AND due_date <= ?;
 	`
 
 	getTasksRangeQuery = `
@@ -582,7 +584,7 @@ func GetUserTask(id, login string) (*Task, error) {
 }
 
 // GetAllTasks returns list of tasks in some timeframe for all promotions
-func GetAllTasks() ([]Task, error) {
+func GetAllTasks(start, end time.Time) ([]Task, error) {
 	tx, err := db.DB.Beginx()
 	if err != nil {
 		return nil, err
@@ -591,7 +593,7 @@ func GetAllTasks() ([]Task, error) {
 	defer checkErr(tx, err)
 
 	var tasks []Task
-	err = tx.Select(&tasks, getAllTasksQuery)
+	err = tx.Select(&tasks, getAllTasksQuery, start, end)
 	return tasks, err
 }
 

--- a/models/task.go
+++ b/models/task.go
@@ -95,6 +95,37 @@ const (
 		WHERE short_id = ? AND deleted=0;
 	`
 
+	getAllTasksQuery = `
+		SELECT
+			tasks.short_id,
+			tasks.promotion,
+			tasks.visibility,
+			tasks.members,
+			tasks.class,
+			tasks.title,
+			tasks.subject,
+			tasks.semester,
+			tasks.content,
+			tasks.region,
+			tasks.due_date,
+			users.name as created_by,
+			updated_user.name as updated_by,
+			tasks.created_by_login,
+			tasks.updated_by_login,
+			tasks.created_at,
+			tasks.updated_at
+		FROM tasks
+		LEFT JOIN users
+		ON 
+			users.login = tasks.created_by_login
+		LEFT JOIN users as updated_user
+		ON
+			updated_user.login = tasks.updated_by_login
+		WHERE 
+			tasks.visibility='promotion'
+			AND deleted=0;
+	`
+
 	getTasksRangeQuery = `
 		SELECT
 			tasks.short_id,
@@ -550,19 +581,19 @@ func GetUserTask(id, login string) (*Task, error) {
 	return &task, err
 }
 
-// GetTasksRange returns list of tasks in a time for a specific class promotion
-// func GetAllTasks(filters Filters) ([]Task, error) {
-// 	tx, err := db.DB.Beginx()
-// 	if err != nil {
-// 		return nil, err
-// 	}
+// GetAllTasks returns list of tasks in some timeframe for all promotions
+func GetAllTasks() ([]Task, error) {
+	tx, err := db.DB.Beginx()
+	if err != nil {
+		return nil, err
+	}
 
-// 	defer checkErr(tx, err)
+	defer checkErr(tx, err)
 
-// 	var tasks []Task
-// 	err = tx.Select(&tasks, getTasksRangeQuery, user.Login, filters.Visibility, filters.Subject, filters.Completed, user.Login, user.Promotion, user.Class, user.Region, user.Semester, user.Promotion, user.Semester, "%"+user.Login+"%", user.Login, filters.StartDate, filters.EndDate)
-// 	return tasks, err
-// }
+	var tasks []Task
+	err = tx.Select(&tasks, getAllTasksQuery)
+	return tasks, err
+}
 
 // GetTasksRange returns list of tasks in a time for a specific class promotion
 func GetTasksRange(user User, filters Filters) ([]Task, error) {

--- a/models/user.go
+++ b/models/user.go
@@ -145,6 +145,10 @@ func GetUserByEmail(email string) (*User, error) {
 
 // GetUser retrives user by login
 func GetUser(login string) (*User, error) {
+	if login == "api_key" {
+		return &User{Login: "api_key"}, nil
+	}
+
 	tx, err := db.DB.Beginx()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Changes added:
1. `api_keys` sql table, for storing all valid keys
2. middleware: authorizes access only to `/v1/tasks` if the request is made from an API key
3. `/v1/tasks` will return all task in a specific timeframe if the request is made from an API key
4. tests added to `tasks_test.go`
5. `Get_User` will return an empty user with login `api_key` if requested login is `api_key`
6. `epitaf apikey` command to generate and insert a new API key

Any new API keys must be added either by adding one to the database or through the builtin command `./epitaf apikey`

All changes were tested manually and through go tests.

Thank you :)